### PR TITLE
Redefine validity for records

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -8,22 +8,16 @@ on:
   pull_request:
 
 jobs:
-  build:
-    permissions:
-      contents: write
-      pull-requests: read
-      statuses: write
+  Documenter:
+    name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v2
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
         with:
-          version: 'nightly'
-      - uses: julia-actions/cache@v1
-      - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
-      - name: Build and deploy
+          version: '1'
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-docdeploy@latest
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # If authenticating with GitHub Actions token
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # If authenticating with SSH deploy key
-        run: julia --project=docs/ docs/make.jl
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -8,35 +8,34 @@ on:
 
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
+      fail-fast: false
       matrix:
-        julia-version:
-          - 'nightly'
-        os: [ ubuntu-latest, windows-latest ]
-        arch: [ x64 ]
+        julia-version: ['1', '1.11']
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+        experimental: [false]
         include:
+          # Include nightly, but experimental, so it's allowed to fail without
+          # failing CI.
           - julia-version: nightly
-            julia-arch: x86
             os: ubuntu-latest
             experimental: true
-         # - julia-version: 1
-         #   os: macOS-latest
-         #   experimental: false
+            fail_ci_if_error: false
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Julia
-        uses: julia-actions/setup-julia@v1
+        uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.julia-version }}
       - name: Run Tests
         uses: julia-actions/julia-runtest@latest
       - name: Create CodeCov
-        uses: julia-actions/julia-processcoverage@v1
+        uses: julia-actions/julia-processcoverage@latest
       - name: Upload CodeCov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v4
         with:
           file: ./lcov.info
           flags: unittests

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,5 +3,6 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 MemoryViews = "a791c907-b98b-4e44-8f4d-e4c2362c6b2f"
 XAMAuxData = "e99d641e-1821-45d7-9150-ecb7bf333fe1"
 
-[sources]
-XAMAuxData = {path = ".."}
+[compat]
+Documenter = "1"
+MemoryViews = "0.2"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,33 +1,25 @@
 using Documenter, XAMAuxData
 
 meta = quote
-    using XAMAuxData: SAM, BAM, AuxTag, Hex, Errors, Error
+    using XAMAuxData: SAM, BAM, AuxTag, Hex, Errors, Error, is_well_formed
     using MemoryViews: MemoryView
     line = "AK:z:some string\ts1:i:2512\tst:A:+\tas:f:211.2\tar:B:c3,-16,21,-100"
 end
 
-DocMeta.setdocmeta!(
-    XAMAuxData,
-    :DocTestSetup,
-    meta,
-    recursive=true
-)
+DocMeta.setdocmeta!(XAMAuxData, :DocTestSetup, meta; recursive=true)
 
-makedocs(
-    sitename = "XAMAuxData.jl",
-    modules = [XAMAuxData],
-    pages = [
-        "Home" => "index.md",
-        "Reference" => "reference.md",
-    ],
-    authors = "Jakob Nybo Nissen",
-    checkdocs = :public,
+makedocs(;
+    sitename="XAMAuxData.jl",
+    modules=[XAMAuxData],
+    pages=["Home" => "index.md", "Reference" => "reference.md"],
+    authors="Jakob Nybo Nissen",
+    checkdocs=:public,
     remotes=nothing,
 )
 
-deploydocs(
-    repo = "github.com/BioJulia/XAMAuxData.jl.git",
-    push_preview = true,
-    deps = nothing,
-    make = nothing,
+deploydocs(;
+    repo="github.com/BioJulia/XAMAuxData.jl.git",
+    push_preview=true,
+    deps=nothing,
+    make=nothing,
 )

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -1,7 +1,7 @@
 ```@meta
 CurrentModule = XAMAuxData
 DocTestSetup = quote
-    using XAMAuxData: BAM, SAM, AuxTag, Hex, Errors, Error
+    using XAMAuxData: BAM, SAM, AuxTag, Hex, Errors, Error, is_well_formed
 end
 ```
 
@@ -13,5 +13,6 @@ Error
 Errors
 SAM.Auxiliary
 BAM.Auxiliary
+is_well_formed
 Base.isvalid(::XAMAuxData.AbstractAuxiliary)
 ```

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -206,7 +206,6 @@ end
         for c in Any[
             'w',
             '1',
-            Base.AnnotatedChar('!', [:some=>1]),
         ]
             aux["k1"] = c
             @test String(MemoryView(aux)) == "k1:A:" * Char(c)
@@ -422,7 +421,6 @@ end
         for c in Any[
             'w',
             '1',
-            Base.AnnotatedChar('!', [:some=>1]),
         ]
             aux["k1"] = c
             @test aux["k1"] === Char(c)


### PR DESCRIPTION
Now, distinguish between well-formed and valid records, as described in the new documentation.