### PR TITLE
support StringViews 2.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ StringViews = "354b36f9-a18e-4713-926e-db85100087ba"
 Aqua = "0.8.7"
 FormatSpecimens = "1.3.0"
 MemoryViews = "0.3.3, 0.4"
-StringViews = "1.3.3"
+StringViews = "1.3.3, 2"
 Test = "1.11"
 julia = "1.11"
 


### PR DESCRIPTION
Updates the package to use StringViews 2.0 if available (which has minor breaking changes with 1.0 that shouldn't affect this package). In Julia 1.14, where the StringView type is merged into Base, the StringViews 2.0 package becomes a simple stub around the Base type.